### PR TITLE
fix: pass --no-ext-diff --no-color to git diff

### DIFF
--- a/.changeset/fix-no-ext-diff.md
+++ b/.changeset/fix-no-ext-diff.md
@@ -1,0 +1,5 @@
+---
+"diffx-cli": patch
+---
+
+All internal `git diff` invocations now pass `--no-ext-diff --no-color`, so the frontend always receives a standard unified diff regardless of the user's global git configuration.

--- a/src/git.ts
+++ b/src/git.ts
@@ -74,20 +74,24 @@ export function getBranchName(): string {
   }
 }
 
+// Force standard unified diff regardless of user's git config
+// (e.g. diff.external = difftastic, color.ui = always).
+const DIFF_FLAGS = ['--no-ext-diff', '--no-color'] as const
+
 export function getCustomGitDiff(args: string[]): string {
-  return execFileSync('git', ['diff', ...args], { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 })
+  return execFileSync('git', ['diff', ...DIFF_FLAGS, ...args], { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 })
 }
 
 export function getGitDiff(options: { staged?: boolean; untracked?: boolean } = {}): string {
   const parts: string[] = []
 
   // unstaged changes (always included as the base)
-  const unstaged = execFileSync('git', ['diff'], { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 })
+  const unstaged = execFileSync('git', ['diff', ...DIFF_FLAGS], { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 })
   if (unstaged) parts.push(unstaged)
 
   // staged changes
   if (options.staged) {
-    const staged = execFileSync('git', ['diff', '--staged'], { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 })
+    const staged = execFileSync('git', ['diff', ...DIFF_FLAGS, '--staged'], { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 })
     if (staged) parts.push(staged)
   }
 


### PR DESCRIPTION
## Problem

When the user has `diff.external` (e.g. difftastic, delta) or `GIT_EXTERNAL_DIFF` configured, `git diff` emits the external tool's format instead of unified diff. The frontend parser silently fails and the page renders blank.

`color.ui = always` causes the same kind of breakage via ANSI escapes.

## Fix

Pass `--no-ext-diff --no-color` on every `git diff` call that feeds the frontend parser. These are git's official escape hatches for tool integration.