### PR TITLE
feat: add --host flag to bind the server to a custom address

### DIFF
--- a/.changeset/custom-host-flag.md
+++ b/.changeset/custom-host-flag.md
@@ -1,0 +1,5 @@
+---
+"diffx-cli": minor
+---
+
+add `--host` flag to bind the server to a custom address (e.g. `0.0.0.0` for LAN access)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { startServer } from './server.js'
 const { values, positionals } = parseArgs({
   options: {
     port: { type: 'string', short: 'p' },
+    host: { type: 'string' },
     'no-open': { type: 'boolean', default: false },
     help: { type: 'boolean' },
     version: { type: 'boolean', short: 'v' },
@@ -24,6 +25,8 @@ Usage: diffx [options] [-- <git diff args>]
 
 Options:
   -p, --port <port>  Port to run the server on (default: random available port)
+  --host <host>      Host address to bind to (default: 127.0.0.1). Pass
+                     0.0.0.0 to expose the server to the local network.
   --no-open          Don't open the browser automatically
   -v, --version      Show version number
   -h, --help         Show this help message
@@ -32,7 +35,8 @@ Examples:
   diffx                        Review uncommitted changes
   diffx -- --staged            Review staged changes
   diffx -- HEAD~3              Review last 3 commits
-  diffx -- main..feature       Compare branches`)
+  diffx -- main..feature       Compare branches
+  diffx --host 0.0.0.0         Allow other machines on the LAN to review`)
   process.exit(0)
 }
 
@@ -52,6 +56,7 @@ if (!isGitRepo()) {
 }
 
 const port = await getPort(values.port ? { port: parseInt(values.port, 10) } : undefined)
+const host = values.host ?? '127.0.0.1'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const clientDir = resolve(__dirname, 'client')
@@ -60,14 +65,17 @@ const resolvedClientDir = existsSync(clientDir)
   ? clientDir
   : resolve(process.cwd(), 'dist/client')
 
-const { port: actualPort } = await startServer({ port, clientDir: resolvedClientDir, customDiffArgs })
-const localUrl = `http://127.0.0.1:${actualPort}`
+const { port: actualPort } = await startServer({ port, host, clientDir: resolvedClientDir, customDiffArgs })
+
+const localUrl = `http://${host}:${actualPort}`
 
 console.log(`diffx server running at ${localUrl}`)
 
 if (!values['no-open']) {
+  const openHost = host === '0.0.0.0' ? '127.0.0.1' : host
+  const openUrl = `http://${openHost}:${actualPort}`
   const openModule = await import('open')
-  openModule.default(localUrl)
+  openModule.default(openUrl)
 }
 
 process.on('SIGINT', () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -223,6 +223,7 @@ export function createApp(clientDir: string, customDiffArgs?: string[], commentS
 
 export function startServer(options: {
   port: number
+  host: string
   clientDir: string
   customDiffArgs?: string[]
 }): Promise<{ port: number }> {
@@ -232,7 +233,7 @@ export function startServer(options: {
     const server = serve({
       fetch: app.fetch,
       port: options.port,
-      hostname: '127.0.0.1',
+      hostname: options.host,
     }, (info) => {
       resolve({ port: info.port })
     })


### PR DESCRIPTION
Add a `--host` flag (default `127.0.0.1`) that is forwarded to the server's `hostname` option. Passing `--host 0.0.0.0` binds all interfaces so other machines on the same LAN can load the review UI.

The banner and `open()` call fall back to `127.0.0.1` when the bind host is `0.0.0.0`, since browsers handle `http://0.0.0.0` inconsistently across platforms. Default behavior is unchanged; LAN exposure is strictly opt-in.