### PR TITLE
feat(ui): add toggleable sidebar on mobile

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -152,7 +152,7 @@ export function App() {
         defaultTabSize={settings.defaultTabSize}
         customMode={customMode}
         sidebarOpen={sidebarOpen}
-        onSidebarToggle={() => setSidebarOpen(!sidebarOpen)}
+        onSidebarToggle={() => setSidebarOpen((open) => !open)}
         onDiffStyleChange={(style) => updateSettings({ diffStyle: style })}
         onDiffOptionsChange={(options) => updateSettings(options)}
         onDefaultTabSizeChange={(size) => updateSettings({ defaultTabSize: size })}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useRef } from 'react'
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { parsePatchFiles } from '@pierre/diffs'
 import type { FileDiffMetadata } from '@pierre/diffs'
 import type { ReviewComment } from '../types'
@@ -20,6 +20,17 @@ export function App() {
   const { comments, addComment, removeComment, copyAllComments } =
     useComments()
   const [activeFile, setActiveFile] = useState<string | null>(null)
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth > 768) {
+        setSidebarOpen(false)
+      }
+    }
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
   const { viewedFiles, setViewed } = useViewed()
   const diffViewerRef = useRef<HTMLDivElement>(null)
 
@@ -140,20 +151,29 @@ export function App() {
         diffOptions={{ staged: settings.staged, untracked: settings.untracked }}
         defaultTabSize={settings.defaultTabSize}
         customMode={customMode}
+        sidebarOpen={sidebarOpen}
+        onSidebarToggle={() => setSidebarOpen(!sidebarOpen)}
         onDiffStyleChange={(style) => updateSettings({ diffStyle: style })}
         onDiffOptionsChange={(options) => updateSettings(options)}
         onDefaultTabSizeChange={(size) => updateSettings({ defaultTabSize: size })}
         onCopyComments={copyAllComments}
       />
       <div className="app-body">
-        <aside className="sidebar">
+        <div
+          className={`sidebar-overlay ${sidebarOpen ? 'sidebar-overlay-open' : ''}`}
+          onClick={() => setSidebarOpen(false)}
+        />
+        <aside className={`sidebar ${sidebarOpen ? 'sidebar-open' : ''}`}>
           <FileTree
             files={files}
             activeFile={activeFile}
             commentCounts={commentCounts}
             viewedFiles={viewedFiles}
             untrackedFiles={untrackedSet}
-            onFileClick={handleFileClick}
+            onFileClick={(file) => {
+              handleFileClick(file)
+              setSidebarOpen(false)
+            }}
           />
           <CommentTracker comments={comments} />
         </aside>

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { GitBranch, Settings } from 'lucide-react'
+import { GitBranch, Settings, FolderTree } from 'lucide-react'
 import type { DiffOptions } from '../hooks/useDiff'
 
 interface ToolbarProps {
@@ -13,6 +13,8 @@ interface ToolbarProps {
   diffOptions: DiffOptions
   defaultTabSize: number
   customMode: boolean
+  sidebarOpen: boolean
+  onSidebarToggle: () => void
   onDiffStyleChange: (style: 'split' | 'unified') => void
   onDiffOptionsChange: (options: DiffOptions) => void
   onDefaultTabSizeChange: (size: number) => void
@@ -30,6 +32,8 @@ export function Toolbar({
   diffOptions,
   defaultTabSize,
   customMode,
+  sidebarOpen,
+  onSidebarToggle,
   onDiffStyleChange,
   onDiffOptionsChange,
   onDefaultTabSizeChange,
@@ -60,6 +64,14 @@ export function Toolbar({
   return (
     <div className="toolbar">
       <div className="toolbar-left">
+        <button
+          className="sidebar-toggle-btn"
+          onClick={onSidebarToggle}
+          title="Toggle sidebar"
+          aria-label="Toggle sidebar"
+        >
+          <FolderTree size={18} />
+        </button>
         <h1 className="toolbar-title">{repoName}</h1>
         {branch && (
           <span className="toolbar-branch">

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -65,10 +65,12 @@ export function Toolbar({
     <div className="toolbar">
       <div className="toolbar-left">
         <button
-          className="sidebar-toggle-btn"
+          className={`sidebar-toggle-btn${sidebarOpen ? ' active' : ''}`}
           onClick={onSidebarToggle}
-          title="Toggle sidebar"
-          aria-label="Toggle sidebar"
+          title={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+          aria-label={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+          aria-expanded={sidebarOpen}
+          aria-pressed={sidebarOpen}
         >
           <FolderTree size={18} />
         </button>

--- a/src/ui/styles/global.css
+++ b/src/ui/styles/global.css
@@ -970,6 +970,7 @@ body {
     display: none;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
     width: 32px;
     height: 32px;
     border: 1px solid var(--border);
@@ -989,7 +990,7 @@ body {
     position: fixed;
     inset: 0;
     background: rgba(0, 0, 0, 0.4);
-    z-index: 150;
+    z-index: 90;
 }
 
 @media (max-width: 768px) {
@@ -1003,11 +1004,7 @@ body {
 
     .sidebar {
         position: fixed;
-        top: 41px;
         left: -320px;
-        width: 300px;
-        min-width: 300px;
-        height: calc(100vh - 41px);
         z-index: 200;
         transition: left 0.25s ease-in-out;
         box-shadow: 2px 0 12px rgba(0, 0, 0, 0.15);

--- a/src/ui/styles/global.css
+++ b/src/ui/styles/global.css
@@ -964,3 +964,64 @@ body {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+/* Mobile sidebar toggle */
+.sidebar-toggle-btn {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-secondary);
+    color: var(--text);
+    cursor: pointer;
+    margin-right: 8px;
+}
+
+.sidebar-toggle-btn:hover {
+    background: var(--border);
+}
+
+.sidebar-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 150;
+}
+
+@media (max-width: 768px) {
+    .sidebar-toggle-btn {
+        display: flex;
+    }
+
+    .app-body {
+        position: relative;
+    }
+
+    .sidebar {
+        position: fixed;
+        top: 41px;
+        left: -320px;
+        width: 300px;
+        min-width: 300px;
+        height: calc(100vh - 41px);
+        z-index: 200;
+        transition: left 0.25s ease-in-out;
+        box-shadow: 2px 0 12px rgba(0, 0, 0, 0.15);
+    }
+
+    .sidebar.sidebar-open {
+        left: 0;
+    }
+
+    .sidebar-overlay.sidebar-overlay-open {
+        display: block;
+    }
+
+    .main {
+        padding: 16px;
+    }
+}


### PR DESCRIPTION
This PR adds a toggleable sidebar for mobile screens (< 768px viewport width), making the file tree accessible on phones and tablets.

## Changes

- Added a `FolderTree` toggle button in the toolbar (visible only on mobile)
- Sidebar transforms into an off-canvas drawer that slides in from the left
- Semi-transparent overlay backdrop to dismiss the sidebar
- Auto-closes when a file is selected or the viewport is resized above 768px
- Smooth slide transition with box-shadow for depth

## Before

The sidebar was fixed at 300px wide with no responsive behavior, causing horizontal overflow on mobile devices.

## After

On screens ≤768px, the sidebar is hidden by default and can be toggled via the tree icon in the toolbar. On desktop, the sidebar remains always visible as before.

## Screenshots

<img width="892" height="872" alt="Screenshot From 2026-04-11 01-57-00" src="https://github.com/user-attachments/assets/130679dc-59d2-45b7-b4fc-24a802a1d75c" />

<img width="892" height="872" alt="Screenshot From 2026-04-11 01-57-07" src="https://github.com/user-attachments/assets/886b33d7-fe9d-40d1-b31f-ff21ae09fa57" />


## Testing

- Open DevTools, toggle device toolbar, test at various viewport widths
- Verified on real mobile device via network-exposed dev server
