### PR TITLE
Mark files as not viewed when their content changes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -82,7 +82,7 @@ export function createApp(clientDir: string, customDiffArgs?: string[], commentS
   const app = new Hono()
   const isCustomMode = !!customDiffArgs
   const store = commentStore ?? new InMemoryCommentStore()
-  const viewedFiles = new Set<string>()
+  const viewedFiles = new Map<string, string>()
 
   app.get('/api/diff', (c) => {
     let patch: string
@@ -131,13 +131,16 @@ export function createApp(clientDir: string, customDiffArgs?: string[], commentS
   })
 
   app.get('/api/viewed', (c) => {
-    return c.json([...viewedFiles])
+    return c.json(Object.fromEntries(viewedFiles))
   })
 
   app.put('/api/viewed', async (c) => {
-    const { filePath, viewed } = await c.req.json<{ filePath: string; viewed: boolean }>()
+    const { filePath, viewed, contentHash } = await c.req.json<{ filePath: string; viewed: boolean; contentHash?: string }>()
     if (viewed) {
-      viewedFiles.add(filePath)
+      if (typeof contentHash !== 'string' || contentHash.length === 0) {
+        return c.json({ error: 'non-empty contentHash required when marking viewed' }, 400)
+      }
+      viewedFiles.set(filePath, contentHash)
     } else {
       viewedFiles.delete(filePath)
     }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -27,7 +27,6 @@ export function App() {
       return false
     }
   })
-  const { viewedFiles, setViewed } = useViewed()
   const diffViewerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -67,6 +66,8 @@ export function App() {
       return []
     }
   }, [patch, binaryFiles])
+
+  const { viewedFiles, setViewed } = useViewed(files)
 
   const diffStats = useMemo(() => {
     if (!patch) return { additions: 0, deletions: 0 }

--- a/src/ui/hooks/useViewed.ts
+++ b/src/ui/hooks/useViewed.ts
@@ -1,34 +1,65 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type { FileDiffMetadata } from '@pierre/diffs'
 
 const VIEWED_KEY = ['viewed']
 
-async function fetchViewed(): Promise<string[]> {
+type ViewedMap = Record<string, string>
+
+async function fetchViewed(): Promise<ViewedMap> {
   const res = await fetch('/api/viewed')
-  return res.json()
+  const data = await res.json()
+  return data && typeof data === 'object' && !Array.isArray(data) ? data : {}
 }
 
-export function useViewed() {
+export function useViewed(files: FileDiffMetadata[]) {
   const queryClient = useQueryClient()
-  const { data: viewedList = [] } = useQuery({ queryKey: VIEWED_KEY, queryFn: fetchViewed })
+  const { data: viewedMap = {} } = useQuery({ queryKey: VIEWED_KEY, queryFn: fetchViewed })
 
-  const viewedFiles = new Set(viewedList)
+  const fileHashByName = useMemo(() => {
+    const map: Record<string, string | undefined> = {}
+    for (const f of files) map[f.name] = f.newObjectId
+    return map
+  }, [files])
+
+  const viewedFiles = useMemo(() => {
+    const set = new Set<string>()
+    for (const f of files) {
+      const stored = viewedMap[f.name]
+      if (stored === undefined) continue
+      const oid = f.newObjectId
+      if (oid ? stored === oid : stored === '') set.add(f.name)
+    }
+    return set
+  }, [viewedMap, files])
 
   const setViewed = useCallback(async (filePath: string, viewed: boolean) => {
-    // Optimistic update
-    queryClient.setQueryData<string[]>(VIEWED_KEY, (prev = []) => {
+    const contentHash = fileHashByName[filePath] ?? ''
+
+    await queryClient.cancelQueries({ queryKey: VIEWED_KEY })
+    queryClient.setQueryData<ViewedMap>(VIEWED_KEY, (prev = {}) => {
+      const next = { ...prev }
       if (viewed) {
-        return prev.includes(filePath) ? prev : [...prev, filePath]
+        next[filePath] = contentHash
+      } else {
+        delete next[filePath]
       }
-      return prev.filter((f) => f !== filePath)
+      return next
     })
 
-    await fetch('/api/viewed', {
+    // Files without a usable content hash (synthetic binary entries) can't be
+    // change-detected — keep them session-cache-only.
+    if (!contentHash) return
+
+    const res = await fetch('/api/viewed', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ filePath, viewed }),
+      body: JSON.stringify({ filePath, viewed, contentHash: viewed ? contentHash : undefined }),
     })
-  }, [queryClient])
+    if (!res.ok) {
+      queryClient.invalidateQueries({ queryKey: VIEWED_KEY })
+    }
+  }, [queryClient, fileHashByName])
 
   return { viewedFiles, setViewed }
 }


### PR DESCRIPTION
## Summary
- Closes [#22](https://github.com/wong2/diffx/issues/22).
- The viewed checkbox now behaves like GitHub's: editing a file you'd previously marked viewed automatically un-marks it, so you're prompted to re-review the new state.
- Implementation: server stores `{filePath → contentHash}` instead of a `Set<string>`. The content hash is the file's git blob OID (`newObjectId` from `@pierre/diffs`). The client derives "effectively viewed" by comparing the stored hash against the current diff's `newObjectId` per file — a mismatch means the file changed since you viewed it, so it drops out of the viewed set.

## Notes
- Files without a usable OID (synthetic `FileDiffMetadata` entries created for binary diffs) are kept session-cache-only: they can be ticked in the current page session, but the state isn't persisted because there's no reliable way to detect changes. This is the conservative choice — better than pretending to have detected nothing.
- Viewed state remains in-memory on the server (lost on server restart), matching the pre-existing behaviour.
- The `useViewed` hook now takes the parsed file list so it can do the OID lookup internally; the component-side `setViewed(filePath, viewed)` signature didn't change, to avoid prop-drilling churn.

## Tests performed
- `pnpm build` and `npx tsc --noEmit` pass cleanly.
- Drove the server API end-to-end against a scratch git repo with `curl`: confirmed `GET /api/viewed` returns the new `Record<path, hash>` shape, `PUT` with a valid OID stores it, `PUT` with empty/missing `contentHash` returns `400`, and after modifying a file the blob OID changes (so the client's hash comparison would correctly drop it from the viewed set).
- Drove the change-invalidation flow in the browser: marked `useViewed.ts` as viewed in the local build's UI, made a trivial edit to the file, refreshed — the file was correctly shown as no longer viewed.
- Did not exercise React-side optimistic-update edge cases (concurrent toggles, window-focus race) in the browser; the `cancelQueries` guard is by inspection only.