### PR TITLE
fix: web UI fails to load on Windows (static path separator)

### DIFF
--- a/.changeset/windows-static-path.md
+++ b/.changeset/windows-static-path.md
@@ -1,0 +1,5 @@
+---
+"diffx-cli": patch
+---
+
+Fix the web UI failing to load on Windows. The static-file guard compared resolved paths against a hardcoded `/`, which never matches Windows' backslash paths, so every asset was rejected with a 403. Compare against the platform separator (`path.sep`) instead.

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,4 +1,4 @@
-import { resolve, isAbsolute } from 'node:path'
+import { resolve, isAbsolute, sep } from 'node:path'
 
 function decodeAndNormalize(p: string): string {
   // Decode URL-encoded characters (e.g. %2e -> ., %2f -> /, %5c -> \)
@@ -18,5 +18,5 @@ export function isSafePath(relativePath: string, baseDir: string): boolean {
     return false
   }
   const resolved = resolve(baseDir, normalized)
-  return resolved.startsWith(resolve(baseDir) + '/') || resolved === resolve(baseDir)
+  return resolved.startsWith(resolve(baseDir) + sep) || resolved === resolve(baseDir)
 }


### PR DESCRIPTION
## What's wrong
On Windows, the web UI doesn't load — `/`, `index.html`, and every `/assets/*`
return `403`. The server and API (`/api/diff`) work fine; only static serving
is blocked.

## Why
`isSafePath` compares the resolved path against `resolve(baseDir) + '/'`. On
Windows `path.resolve()` returns backslash paths, so the `'/'` prefix never
matches and every asset is rejected. CI runs on Linux (`path.sep === '/'`), so
it's not caught.

## Fix
Use `path.sep` instead of a hardcoded `'/'`. Traversal attempts still `403`.

## Repro
On Windows, run `diffx` → browser shows `Forbidden`. With the fix, the UI loads
(`/` and `/assets/*` → `200`).
