### PR TITLE
feat: expand context above/below changes (#26)

### DIFF
--- a/.changeset/expand-hunk-context.md
+++ b/.changeset/expand-hunk-context.md
@@ -1,0 +1,5 @@
+---
+'diffx-cli': minor
+---
+
+Add expand-context controls above and below each change region, revealing the next 20 unchanged lines per click (#26)

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process'
 import { basename, join, resolve } from 'node:path'
-import { readFileSync } from 'node:fs'
+import { readFileSync, lstatSync, readlinkSync } from 'node:fs'
 import { isSafePath } from './path.js'
 import { parseSync as parseEditorConfig, type ProcessedFileConfig } from 'editorconfig'
 
@@ -42,6 +42,42 @@ export function getFileContent(filePath: string, version: 'old' | 'new'): Buffer
   // old version: try staged first, then HEAD
   try {
     return execFileSync('git', ['show', `HEAD:${filePath}`], { stdio: 'pipe', maxBuffer: 50 * 1024 * 1024 })
+  } catch {
+    return null
+  }
+}
+
+const BLOB_OID_REGEX = /^[0-9a-f]{4,64}$/
+
+export function getBlobContent(oid: string): string | null {
+  if (!BLOB_OID_REGEX.test(oid) || /^0+$/.test(oid)) {
+    return null
+  }
+  try {
+    return execFileSync('git', ['cat-file', 'blob', oid], { encoding: 'utf-8', stdio: 'pipe', maxBuffer: 50 * 1024 * 1024 })
+  } catch {
+    return null
+  }
+}
+
+export function getWorktreeFileContent(filePath: string): string | null {
+  const root = getRepoRoot()
+  if (!isSafePath(filePath, root)) {
+    return null
+  }
+  const resolved = resolve(root, filePath)
+  try {
+    // Match git's notion of the worktree blob: for a symlink that is the
+    // target string, never the contents of the file it points at (which
+    // could be outside the repository).
+    const stats = lstatSync(resolved)
+    if (stats.isSymbolicLink()) {
+      return readlinkSync(resolved, 'utf-8')
+    }
+    if (!stats.isFile()) {
+      return null
+    }
+    return readFileSync(resolved, 'utf-8')
   } catch {
     return null
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { join, extname, resolve } from 'node:path'
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
-import { getGitDiff, getCustomGitDiff, getRepoName, getBranchName, getFileContent, isImageFile, getTabSizeForFiles, getUntrackedFilePaths } from './git.js'
+import { getGitDiff, getCustomGitDiff, getRepoName, getBranchName, getFileContent, getBlobContent, getWorktreeFileContent, isImageFile, getTabSizeForFiles, getUntrackedFilePaths } from './git.js'
 import { loadSettings, saveSettings } from './settings.js'
 import { InMemoryCommentStore } from './comments.js'
 import type { CommentStore } from './comments.js'
@@ -78,6 +78,18 @@ function parseBinaryFiles(patch: string, untrackedFiles?: Set<string>): BinaryFi
   return binaryFiles
 }
 
+function diffContainsFileVersion(patch: string, path: string, oldOid: string, newOid: string): boolean {
+  for (const chunk of patch.split(/^(?=diff --git )/m)) {
+    // Match the new-file path from the `+++ b/<path>` header (as the client
+    // does); the `diff --git` line is ambiguous for paths containing ` b/`.
+    const nameMatch = chunk.match(/^\+\+\+ [ab]\/([^\t\r\n]+)/m)
+    if (!nameMatch || nameMatch[1].trim() !== path) continue
+    const indexMatch = chunk.match(/^index ([0-9a-f]+)\.\.([0-9a-f]+)/m)
+    if (indexMatch && indexMatch[1] === oldOid && indexMatch[2] === newOid) return true
+  }
+  return false
+}
+
 export function createApp(clientDir: string, customDiffArgs?: string[], commentStore?: CommentStore) {
   const app = new Hono()
   const isCustomMode = !!customDiffArgs
@@ -118,6 +130,38 @@ export function createApp(clientDir: string, customDiffArgs?: string[], commentS
     return new Response(new Uint8Array(content), {
       headers: { 'Content-Type': contentType },
     })
+  })
+
+  // Full old/new file contents for a diffed file, so the client can build a
+  // non-partial diff that supports expanding context around hunks.
+  // `oldOid`/`newOid` are blob ids from the patch's `index` line. The diff is
+  // regenerated and the requested oids must match its `index` line for the
+  // requested path: this keeps arbitrary repository blobs unreachable, and
+  // rejects requests whose patch no longer matches the worktree (git recomputes
+  // the worktree blob hash on every diff, so any edit changes the new oid).
+  app.get('/api/file-versions', (c) => {
+    const path = c.req.query('path')
+    const oldOid = c.req.query('oldOid')
+    const newOid = c.req.query('newOid')
+    if (!path || !oldOid || !newOid) {
+      return c.json({ error: 'Missing path or oids' }, 400)
+    }
+    const staged = c.req.query('staged') === 'true'
+    const untracked = c.req.query('untracked') === 'true'
+    const patch = isCustomMode ? getCustomGitDiff(customDiffArgs) : getGitDiff({ staged, untracked })
+    if (!diffContainsFileVersion(patch, path, oldOid, newOid)) {
+      return c.json({ error: 'File version not in current diff' }, 404)
+    }
+    // A zero oid is git's `/dev/null` — an absent side (creation/deletion), so
+    // its content is empty. A non-zero oid that is missing from the object
+    // database is the worktree blob of an unstaged change (git computes its
+    // hash without storing it), so fall back to reading the worktree.
+    const oldContent = /^0+$/.test(oldOid) ? '' : getBlobContent(oldOid)
+    const newContent = /^0+$/.test(newOid) ? '' : getBlobContent(newOid) ?? getWorktreeFileContent(path)
+    if (oldContent == null || newContent == null) {
+      return c.json({ error: 'Content unavailable' }, 404)
+    }
+    return c.json({ old: oldContent, new: newContent })
   })
 
   app.get('/api/settings', (c) => {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,6 +6,7 @@ import { useDiff } from './hooks/useDiff'
 import { useComments } from './hooks/useComments'
 import { useSettings } from './hooks/useSettings'
 import { useViewed } from './hooks/useViewed'
+import { useFullDiffs, fileKey } from './hooks/useFullDiffs'
 import { Toolbar } from './components/Toolbar'
 import { DiffViewer } from './components/DiffViewer'
 import { FileTree } from './components/FileTree'
@@ -66,6 +67,12 @@ export function App() {
       return []
     }
   }, [patch, binaryFiles])
+
+  const fullFiles = useFullDiffs(patch, files, { staged: settings.staged, untracked: settings.untracked })
+  const displayFiles = useMemo(() => {
+    if (fullFiles.size === 0) return files
+    return files.map((f) => fullFiles.get(fileKey(f)) ?? f)
+  }, [files, fullFiles])
 
   const { viewedFiles, setViewed } = useViewed(files)
 
@@ -177,7 +184,7 @@ export function App() {
         </aside>
         <main className="main" ref={diffViewerRef}>
           <DiffViewer
-            files={files}
+            files={displayFiles}
             diffStyle={settings.diffStyle}
             tabSizeMap={tabSizeMap}
             defaultTabSize={settings.defaultTabSize}

--- a/src/ui/components/FileDiffCard.tsx
+++ b/src/ui/components/FileDiffCard.tsx
@@ -39,6 +39,11 @@ export const FileDiffCard = memo(function FileDiffCard({
 
   const getLineContent = (side: AnnotationSide, lineNumber: number): string => {
     const lines = side === 'additions' ? fileDiff.additionLines : fileDiff.deletionLines
+    // Full (non-partial) diffs carry the entire file, so any line — including
+    // expanded context outside hunks — can be addressed directly.
+    if (!fileDiff.isPartial) {
+      return lines[lineNumber - 1] ?? ''
+    }
     const startKey = side === 'additions' ? 'additionStart' : 'deletionStart'
     const countKey = side === 'additions' ? 'additionCount' : 'deletionCount'
     const indexKey = side === 'additions' ? 'additionLineIndex' : 'deletionLineIndex'
@@ -86,6 +91,7 @@ export const FileDiffCard = memo(function FileDiffCard({
             fileDiff={fileDiff}
             options={{
               diffStyle,
+              expansionLineCount: 20,
               enableGutterUtility: true,
               theme: { dark: 'github-dark', light: 'github-light' },
               themeType: 'system',

--- a/src/ui/hooks/useFullDiffs.ts
+++ b/src/ui/hooks/useFullDiffs.ts
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from 'react'
+import { processFile } from '@pierre/diffs'
+import type { FileDiffMetadata } from '@pierre/diffs'
+
+const ZERO_OID = /^0+$/
+
+export function fileKey(file: FileDiffMetadata): string {
+  return `${file.name}\0${file.prevObjectId ?? ''}\0${file.newObjectId ?? ''}`
+}
+
+// Derive the new-file path the same way @pierre/diffs builds `file.name`: from
+// the `+++ b/<path>` header (FILENAME_HEADER_REGEX_GIT). The `diff --git` line
+// is ambiguous for paths containing ` b/`, but this header is not.
+function parseNewPath(chunk: string): string | null {
+  const match = chunk.match(/^\+\+\+ [ab]\/([^\t\r\n]+)/m)
+  return match ? match[1].trim() : null
+}
+
+// Map each per-file patch chunk by name + blob oids so it can be re-processed
+// with full file contents. Keyed on oids too because the same file can appear
+// twice (staged + unstaged chunks).
+function buildChunkMap(patch: string): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const chunk of patch.split(/^(?=diff --git )/m)) {
+    const name = parseNewPath(chunk)
+    if (!name) continue
+    const indexMatch = chunk.match(/^index ([0-9a-f]+)\.\.([0-9a-f]+)/m)
+    const key = `${name}\0${indexMatch?.[1] ?? ''}\0${indexMatch?.[2] ?? ''}`
+    if (!map.has(key)) map.set(key, chunk)
+  }
+  return map
+}
+
+// The fetched contents can diverge from the patch (e.g. the worktree was
+// edited after the diff was captured — for unstaged changes the worktree blob
+// is usually not in the object database, so the server falls back to reading
+// the file from disk). Compare every hunk line from the patch against the
+// full contents at the positions the hunk headers claim; reject on mismatch
+// so expansion never renders code the displayed patch wasn't built from.
+function contentsMatchHunks(partial: FileDiffMetadata, full: FileDiffMetadata): boolean {
+  const norm = (line: string | undefined) => (line ?? '\0').replace(/\r?\n$/, '')
+  for (const hunk of partial.hunks) {
+    for (let i = 0; i < hunk.additionCount; i++) {
+      if (norm(partial.additionLines[hunk.additionLineIndex + i]) !== norm(full.additionLines[hunk.additionStart - 1 + i])) {
+        return false
+      }
+    }
+    for (let i = 0; i < hunk.deletionCount; i++) {
+      if (norm(partial.deletionLines[hunk.deletionLineIndex + i]) !== norm(full.deletionLines[hunk.deletionStart - 1 + i])) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+/**
+ * Upgrades patch-parsed (partial) file diffs to full diffs by fetching the
+ * complete old/new file contents, which enables hunk context expansion.
+ * Returns a map from `fileKey(file)` to the upgraded metadata.
+ */
+export function useFullDiffs(patch: string | null, files: FileDiffMetadata[], options: { staged: boolean; untracked: boolean }) {
+  const [fullFiles, setFullFiles] = useState<Map<string, FileDiffMetadata>>(() => new Map())
+  const requested = useRef(new Set<string>())
+  const patchRef = useRef(patch)
+
+  useEffect(() => {
+    if (patchRef.current !== patch) {
+      patchRef.current = patch
+      requested.current = new Set()
+      setFullFiles(new Map())
+    }
+    if (!patch) return
+
+    const chunkMap = buildChunkMap(patch)
+    for (const file of files) {
+      if (!file.isPartial || file.hunks.length === 0) continue
+      if (file.type !== 'change' && file.type !== 'rename-changed') continue
+      const prevOid = file.prevObjectId
+      if (!prevOid || ZERO_OID.test(prevOid) || !file.newObjectId) continue
+      const key = fileKey(file)
+      if (requested.current.has(key)) continue
+      const chunk = chunkMap.get(key)
+      if (!chunk) continue
+      requested.current.add(key)
+
+      const params = new URLSearchParams({
+        path: file.name,
+        oldOid: prevOid,
+        newOid: file.newObjectId ?? '',
+        staged: String(options.staged),
+        untracked: String(options.untracked),
+      })
+      fetch(`/api/file-versions?${params}`)
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data: { old: string; new: string } | null) => {
+          if (!data || patchRef.current !== patch) return
+          const upgraded = processFile(chunk, {
+            cacheKey: `full:${key}`,
+            oldFile: { name: file.prevName ?? file.name, contents: data.old },
+            newFile: { name: file.name, contents: data.new },
+          })
+          if (!upgraded || upgraded.isPartial || !contentsMatchHunks(file, upgraded)) return
+          setFullFiles((prev) => new Map(prev).set(key, upgraded))
+        })
+        .catch(() => {})
+    }
+  }, [patch, files, options.staged, options.untracked])
+
+  return fullFiles
+}


### PR DESCRIPTION
Reveal the next 20 unchanged lines above and below each change region, incrementally, by upgrading patch-parsed diffs to full diffs.

@pierre/diffs only supports hunk expansion for non-partial diffs (ones carrying full file contents), which a git patch lacks. A new /api/file-versions endpoint serves the full old/new contents for a diffed file, and the client re-processes each file's patch chunk with those contents to produce an expandable diff.

The endpoint regenerates the current diff and only returns content when the requested blob oids match that file's index line, so arbitrary repository blobs stay unreachable and stale-worktree requests are rejected. Symlinks return their target string (matching git's blob semantics) rather than the pointed-at file. Paths are parsed from the +++ b/ header to handle names containing " b/".