### PR TITLE
fix: restrict the local API to the diff under review and same-origin callers

### DIFF
--- a/.changeset/harden-local-server.md
+++ b/.changeset/harden-local-server.md
@@ -1,0 +1,5 @@
+---
+"diffx-cli": patch
+---
+
+Restrict the local API to the diff under review and same-origin callers, and resolve symlinks when serving repository files

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import { basename, join, resolve } from 'node:path'
 import { readFileSync, lstatSync, readlinkSync } from 'node:fs'
-import { isSafePath } from './path.js'
+import { isSafePath, resolveWithinDir } from './path.js'
 import { parseSync as parseEditorConfig, type ProcessedFileConfig } from 'editorconfig'
 
 const IMAGE_EXTENSIONS = new Set([
@@ -28,16 +28,21 @@ function isBinaryFile(absolutePath: string): boolean {
 
 export function getFileContent(filePath: string, version: 'old' | 'new'): Buffer | null {
   const root = getRepoRoot()
-  if (!isSafePath(filePath, root)) {
-    return null
-  }
-  const resolved = resolve(root, filePath)
   if (version === 'new') {
+    // Reading the worktree follows symlinks, unlike the git show below, which
+    // returns a link's target text rather than the file it points at.
+    const resolved = resolveWithinDir(filePath, root)
+    if (!resolved) {
+      return null
+    }
     try {
       return readFileSync(resolved)
     } catch {
       return null
     }
+  }
+  if (!isSafePath(filePath, root)) {
+    return null
   }
   // old version: try staged first, then HEAD
   try {
@@ -140,6 +145,32 @@ export function getGitDiff(options: { staged?: boolean; untracked?: boolean } = 
   return parts.join('\n')
 }
 
+function gitFileNames(args: string[]): string[] {
+  const output = execFileSync('git', ['diff', '--name-only', '-z', ...DIFF_FLAGS, ...args], {
+    encoding: 'utf-8',
+    maxBuffer: 50 * 1024 * 1024,
+  })
+  return output.split('\0').filter(Boolean)
+}
+
+// Paths in the diff, asked of git rather than parsed back out of the patch:
+// the `diff --git` header is ambiguous for paths containing ` b/`, and binary
+// files carry no `+++` header to read instead.
+export function getCustomDiffFilePaths(args: string[]): string[] {
+  return gitFileNames(args)
+}
+
+export function getDiffFilePaths(options: { staged?: boolean; untracked?: boolean } = {}): string[] {
+  const paths = new Set(gitFileNames([]))
+  if (options.staged) {
+    for (const path of gitFileNames(['--staged'])) paths.add(path)
+  }
+  if (options.untracked) {
+    for (const path of getUntrackedFilePaths()) paths.add(path)
+  }
+  return [...paths]
+}
+
 export function getTabSizeForFiles(filePaths: string[]): Record<string, number> {
   const root = getRepoRoot()
   const cache = new Map<string, ProcessedFileConfig>()
@@ -160,11 +191,13 @@ export function getTabSizeForFiles(filePaths: string[]): Record<string, number> 
 }
 
 export function getUntrackedFilePaths(): string[] {
-  const output = execFileSync('git', ['ls-files', '--others', '--exclude-standard'], {
+  // -z so paths with newlines or non-ASCII survive intact; git quotes them
+  // otherwise, and a quoted path matches nothing.
+  const output = execFileSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], {
     encoding: 'utf-8',
     maxBuffer: 50 * 1024 * 1024,
-  }).trim()
-  return output ? output.split('\n') : []
+  })
+  return output.split('\0').filter(Boolean)
 }
 
 function getUntrackedFilesDiff(): string {

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from 'node:fs'
 import { resolve, isAbsolute, sep } from 'node:path'
 
 function decodeAndNormalize(p: string): string {
@@ -19,4 +20,24 @@ export function isSafePath(relativePath: string, baseDir: string): boolean {
   }
   const resolved = resolve(baseDir, normalized)
   return resolved.startsWith(resolve(baseDir) + sep) || resolved === resolve(baseDir)
+}
+
+// Symlink-aware containment: `isSafePath` compares lexically, so a link inside
+// baseDir still reads the file it points at. Returns the path to read, or null
+// when it escapes baseDir or does not exist.
+export function resolveWithinDir(relativePath: string, baseDir: string): string | null {
+  if (!isSafePath(relativePath, baseDir)) {
+    return null
+  }
+  const resolved = resolve(baseDir, relativePath)
+  try {
+    const realBase = realpathSync(baseDir)
+    const realTarget = realpathSync(resolved)
+    if (realTarget !== realBase && !realTarget.startsWith(realBase + sep)) {
+      return null
+    }
+    return resolved
+  } catch {
+    return null
+  }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { join, extname, resolve } from 'node:path'
 import { Hono } from 'hono'
 import { serve } from '@hono/node-server'
-import { getGitDiff, getCustomGitDiff, getRepoName, getBranchName, getFileContent, getBlobContent, getWorktreeFileContent, isImageFile, getTabSizeForFiles, getUntrackedFilePaths } from './git.js'
+import { getGitDiff, getCustomGitDiff, getDiffFilePaths, getCustomDiffFilePaths, getRepoName, getBranchName, getFileContent, getBlobContent, getWorktreeFileContent, isImageFile, getTabSizeForFiles, getUntrackedFilePaths } from './git.js'
 import { loadSettings, saveSettings } from './settings.js'
 import { InMemoryCommentStore } from './comments.js'
 import type { CommentStore } from './comments.js'
@@ -90,21 +90,65 @@ function diffContainsFileVersion(patch: string, path: string, oldOid: string, ne
   return false
 }
 
-export function createApp(clientDir: string, customDiffArgs?: string[], commentStore?: CommentStore) {
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]'])
+
+// Normalizes IPv6 brackets and ports, and returns null for anything malformed.
+function hostnameOf(url: string | undefined): string | null {
+  if (!url) return null
+  try {
+    return new URL(url).hostname.toLowerCase() || null
+  } catch {
+    return null
+  }
+}
+
+export function createApp(
+  clientDir: string,
+  customDiffArgs?: string[],
+  commentStore?: CommentStore,
+  options: { restrictToLoopback?: boolean } = {},
+) {
   const app = new Hono()
   const isCustomMode = !!customDiffArgs
   const store = commentStore ?? new InMemoryCommentStore()
   const viewedFiles = new Map<string, string>()
+  const restrictToLoopback = options.restrictToLoopback ?? true
+
+  const patchUnderReview = (staged: boolean, untracked: boolean) =>
+    isCustomMode ? getCustomGitDiff(customDiffArgs) : getGitDiff({ staged, untracked })
+
+  // The client omits staged/untracked when loading file contents, so this is
+  // the widest set it could be displaying.
+  const filesUnderReview = () =>
+    isCustomMode
+      ? getCustomDiffFilePaths(customDiffArgs)
+      : getDiffFilePaths({ staged: true, untracked: true })
+
+  // Host rejects DNS rebinding; Origin rejects cross-site requests from a page
+  // the user has open. A missing Origin (curl, agent skills) is allowed — only
+  // browsers send it, and only browsers can be tricked into sending it. A
+  // non-loopback bind is an opt-in to LAN access, so Host is unchecked there.
+  app.use('/api/*', async (c, next) => {
+    const host = c.req.header('host')
+    const hostname = hostnameOf(host && `http://${host}`)
+    if (restrictToLoopback && (!hostname || !LOOPBACK_HOSTNAMES.has(hostname))) {
+      return c.json({ error: 'Forbidden' }, 403)
+    }
+    const origin = c.req.header('origin')
+    if (origin !== undefined) {
+      const originHostname = hostnameOf(origin)
+      const sameOrigin = originHostname !== null && originHostname === hostname
+      if (!originHostname || (!sameOrigin && !LOOPBACK_HOSTNAMES.has(originHostname))) {
+        return c.json({ error: 'Forbidden' }, 403)
+      }
+    }
+    await next()
+  })
 
   app.get('/api/diff', (c) => {
-    let patch: string
     const staged = c.req.query('staged') === 'true'
     const untracked = c.req.query('untracked') === 'true'
-    if (isCustomMode) {
-      patch = getCustomGitDiff(customDiffArgs)
-    } else {
-      patch = getGitDiff({ staged, untracked })
-    }
+    const patch = patchUnderReview(staged, untracked)
     const repoName = getRepoName()
     const branch = getBranchName()
     const untrackedFiles = untracked ? getUntrackedFilePaths() : []
@@ -120,6 +164,11 @@ export function createApp(clientDir: string, customDiffArgs?: string[], commentS
     const version = c.req.query('version') as 'old' | 'new'
     if (!path || !version) {
       return c.json({ error: 'Missing path or version' }, 400)
+    }
+    // Only files in the diff are served, so unrelated repository files (a
+    // gitignored .env) stay unreachable.
+    if (!filesUnderReview().includes(path)) {
+      return c.json({ error: 'File not in current diff' }, 404)
     }
     const content = getFileContent(path, version)
     if (!content) {
@@ -148,7 +197,7 @@ export function createApp(clientDir: string, customDiffArgs?: string[], commentS
     }
     const staged = c.req.query('staged') === 'true'
     const untracked = c.req.query('untracked') === 'true'
-    const patch = isCustomMode ? getCustomGitDiff(customDiffArgs) : getGitDiff({ staged, untracked })
+    const patch = patchUnderReview(staged, untracked)
     if (!diffContainsFileVersion(patch, path, oldOid, newOid)) {
       return c.json({ error: 'File version not in current diff' }, 404)
     }
@@ -274,7 +323,8 @@ export function startServer(options: {
   clientDir: string
   customDiffArgs?: string[]
 }): Promise<{ port: number }> {
-  const app = createApp(options.clientDir, options.customDiffArgs)
+  const restrictToLoopback = LOOPBACK_HOSTNAMES.has(options.host.toLowerCase())
+  const app = createApp(options.clientDir, options.customDiffArgs, undefined, { restrictToLoopback })
 
   return new Promise((resolve) => {
     const server = serve({

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ export interface Settings {
   untracked: boolean
   diffStyle: 'split' | 'unified'
   defaultTabSize: number
+  softWrap: boolean
   browser?: string
 }
 
@@ -18,20 +19,47 @@ const DEFAULTS: Settings = {
   untracked: true,
   diffStyle: 'split',
   defaultTabSize: 4,
+  softWrap: false,
+}
+
+const BROWSERS = new Set(['chrome', 'firefox', 'edge', 'brave'])
+
+// Settings arrive as an untrusted request body and are written to disk, where
+// `browser` names the app launched on the next run — so keep only known keys.
+function sanitize(input: unknown): Partial<Settings> {
+  if (typeof input !== 'object' || input === null) return {}
+  const raw = input as Record<string, unknown>
+  const settings: Partial<Settings> = {}
+  if (typeof raw.staged === 'boolean') settings.staged = raw.staged
+  if (typeof raw.untracked === 'boolean') settings.untracked = raw.untracked
+  if (typeof raw.softWrap === 'boolean') settings.softWrap = raw.softWrap
+  if (raw.diffStyle === 'split' || raw.diffStyle === 'unified') settings.diffStyle = raw.diffStyle
+  if (
+    typeof raw.defaultTabSize === 'number' &&
+    Number.isInteger(raw.defaultTabSize) &&
+    raw.defaultTabSize >= 1 &&
+    raw.defaultTabSize <= 16
+  ) {
+    settings.defaultTabSize = raw.defaultTabSize
+  }
+  if (typeof raw.browser === 'string' && (raw.browser === '' || BROWSERS.has(raw.browser))) {
+    settings.browser = raw.browser
+  }
+  return settings
 }
 
 export function loadSettings(): Settings {
   try {
     const data = readFileSync(SETTINGS_FILE, 'utf-8')
-    return { ...DEFAULTS, ...JSON.parse(data) }
+    return { ...DEFAULTS, ...sanitize(JSON.parse(data)) }
   } catch {
     return { ...DEFAULTS }
   }
 }
 
-export function saveSettings(settings: Partial<Settings>): Settings {
+export function saveSettings(settings: unknown): Settings {
   const current = loadSettings()
-  const merged = { ...current, ...settings }
+  const merged = { ...current, ...sanitize(settings) }
   mkdirSync(CONFIG_DIR, { recursive: true })
   writeFileSync(SETTINGS_FILE, JSON.stringify(merged, null, 2))
   return merged


### PR DESCRIPTION
The local server answers any caller that can reach the port, and `/api/file-content` serves any file inside the repository. Two commits, one concern each.

### Symlink containment

- `isSafePath` compares lexically, so a symlink stored inside the repo served the contents of whatever it pointed at outside the repo.
- Adds `resolveWithinDir` (realpath-based) for the worktree read. The `git show` path is untouched — it returns a link's target text rather than following it.

### API scope

- `/api/file-content` now serves only paths in the diff under review. Previously any repository file was readable, including gitignored ones such as `.env`.
- Membership comes from `git diff --name-only -z` rather than parsing the patch: the `diff --git` header is ambiguous for paths containing ` b/` (as the `/api/file-versions` comment already notes), and binary files carry no `+++` header to read instead. Side effect: images whose path contains a space now display, where they previously 404'd.
- `/api/*` requires a loopback `Host`, and a same-origin `Origin` when one is present. This stops a page the user happens to have open from posting comments (which the agent skills then apply as code changes) or writing settings, and stops a rebound DNS name from reading the diff.
- `PUT /api/settings` validates keys and values instead of spreading the request body, since `browser` names the application launched on the next run. It is limited to the values the Toolbar offers.

### Kept working on purpose

- Requests with no `Origin` still pass, so the CLI and the `diffx-*` skills are unaffected — only browsers attach that header.
- `--host 0.0.0.0` still serves LAN reviewers. The `Host` check is skipped there, since a non-loopback bind is an explicit opt-in and LAN addresses can't be allowlisted ahead of time; the `Origin` check still applies.
- `getUntrackedFilePaths` gained `-z`. Without it, git quotes paths containing non-ASCII or newline characters, and the new membership check would have regressed those files.
- `softWrap` is now declared in the server's `Settings`. The client already sends it and it was persisting only via the unvalidated spread, so validation would otherwise have dropped it.

